### PR TITLE
Update cmake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(pfxml)
 
 add_library(pfxml INTERFACE)


### PR DESCRIPTION
CMake as deprecated backwards compatibility for cmake versions `< 3.5`:

```zsh
CMake Deprecation Warning at src/xml/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

I'm not sure why you set it so low, so I only increased it to the minimum supported version.